### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,4 +1,6 @@
 name: Check branch fast-forward-ness
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Spring-Easy-Tools/spring-module-tools/security/code-scanning/9](https://github.com/Spring-Easy-Tools/spring-module-tools/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow only checks out the repository and runs a third-party action. No write permissions are needed.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
