### PR TITLE
Исправление нестабильной кодировки в Requester и TestUtils

### DIFF
--- a/src/main/kotlin/ru/virgil/spring/tools/testing/TestUtils.kt
+++ b/src/main/kotlin/ru/virgil/spring/tools/testing/TestUtils.kt
@@ -7,6 +7,7 @@ import org.json.JSONObject
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.test.web.servlet.MvcResult
+import java.nio.charset.StandardCharsets
 import java.util.*
 import java.util.stream.Collectors
 import kotlin.math.min
@@ -42,7 +43,7 @@ class TestUtils(protected val objectMapper: ObjectMapper) {
     }
 
     protected fun extractPrettyResponse(mvcResult: MvcResult): String {
-        var responseContent = mvcResult.response.contentAsString
+        var responseContent = mvcResult.response.getContentAsString(StandardCharsets.UTF_8)
         return when {
             !responseContent.isJson() -> "BODY: content-type -> ${mvcResult.response.contentType}"
             else -> {

--- a/src/main/kotlin/ru/virgil/spring/tools/testing/fluent/request/Requester.kt
+++ b/src/main/kotlin/ru/virgil/spring/tools/testing/fluent/request/Requester.kt
@@ -14,6 +14,7 @@ import org.springframework.util.MimeType
 import org.springframework.util.MimeTypeUtils
 import ru.virgil.spring.tools.testing.TestUtils
 import java.net.URI
+import java.nio.charset.StandardCharsets
 
 class Requester(
     val objectMapper: ObjectMapper,
@@ -73,7 +74,7 @@ class Requester(
             .andReturn()
         val mimeType = MimeTypeUtils.parseMimeType(result.response.contentType ?: MimeTypeUtils.TEXT_PLAIN_VALUE)
         return when {
-            isJson(mimeType, result) -> objectMapper.readValue(result.response.contentAsString)
+            isJson(mimeType, result) -> objectMapper.readValue(result.response.getContentAsString(StandardCharsets.UTF_8))
             isImage(mimeType) -> result.response.contentAsByteArray as T
             else -> result as T
         }
@@ -83,5 +84,5 @@ class Requester(
         mimeType.isPresentIn(listOf(MimeTypeUtils.IMAGE_GIF, MimeTypeUtils.IMAGE_JPEG, MimeTypeUtils.IMAGE_PNG))
 
     fun isJson(mimeType: MimeType, result: MvcResult) =
-        mimeType.isPresentIn(listOf(MimeTypeUtils.APPLICATION_JSON)) && result.response.contentAsString.isNotBlank()
+        mimeType.isPresentIn(listOf(MimeTypeUtils.APPLICATION_JSON)) && result.response.getContentAsString(StandardCharsets.UTF_8).isNotBlank()
 }


### PR DESCRIPTION
This pull request updates how HTTP response content is read in the testing utilities to explicitly specify UTF-8 encoding. This change ensures consistent handling of response data, especially for non-ASCII content, and helps avoid issues related to character encoding.

**Testing utilities improvements:**

* Updated `extractPrettyResponse` in `TestUtils.kt` to use `getContentAsString(StandardCharsets.UTF_8)` instead of `contentAsString` for reading response content with UTF-8 encoding.
* Modified all usages of `contentAsString` in `Requester.kt` to use `getContentAsString(StandardCharsets.UTF_8)` for proper UTF-8 decoding when parsing JSON responses. [[1]](diffhunk://#diff-62e2bb45f6240b0283ee47ef8c3a73e0ac26c4251d4c861b238eaf56e656adf6L76-R77) [[2]](diffhunk://#diff-62e2bb45f6240b0283ee47ef8c3a73e0ac26c4251d4c861b238eaf56e656adf6L86-R87)

**Dependency updates:**

* Added import of `StandardCharsets` in both `TestUtils.kt` and `Requester.kt` to support the new encoding usage. [[1]](diffhunk://#diff-30a68681332d9bffd92d0d0955326c0b6d3985953670aaffa57b81e917254816R10) [[2]](diffhunk://#diff-62e2bb45f6240b0283ee47ef8c3a73e0ac26c4251d4c861b238eaf56e656adf6R17)